### PR TITLE
Use latest mpifileutils main branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,8 @@ RUN wget https://github.com/llnl/dtcmp/releases/download/v1.1.1/dtcmp-1.1.1.tar.
     && ./configure --prefix=/deps/dtcmp/lib --with-lwgrp=/deps/lwgrp/lib \
     && make install
 
-# Until the mpifileutils project accepts the PR work for adding UID/GID to dcp, we need to pull the
-# branch and build from source. See https://github.com/hpc/mpifileutils/pull/540. Once merged,
-# we will still need to pull from master to have dcp -U/-G support until the next release.
-RUN git clone -b add-dcp-uid-gid --depth 1 https://github.com/bdevcich-hpe/mpifileutils.git \
+# Until a new release of mpifileutils is cut, we need to pull the main branch.
+RUN git clone --depth 1 https://github.com/hpc/mpifileutils.git \
     && mkdir build \
     && cd build \
     && cmake ../mpifileutils \

--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ cd deps
   wget https://github.com/hpc/libcircle/releases/download/v0.3/libcircle-0.3.0.tar.gz
   wget https://github.com/llnl/lwgrp/releases/download/v1.0.3/lwgrp-1.0.3.tar.gz
   wget https://github.com/llnl/dtcmp/releases/download/v1.1.1/dtcmp-1.1.1.tar.gz
-  wget https://github.com/libarchive/libarchive/releases/download/3.5.1/libarchive-3.5.1.tar.gz
+  wget https://github.com/libarchive/libarchive/releases/download/v3.5.1/libarchive-3.5.1.tar.gz
 
   tar -zxf libcircle-0.3.0.tar.gz
   cd libcircle-0.3.0


### PR DESCRIPTION
Now that the dcp changes have been merged to the main branch, use the main branch to build our image. This will have to do until a new release is cut.

Also, fix a URL issue with setup.sh.

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>