### PR TITLE
Add nslookup to support NNF Containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021, 2022 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -70,6 +70,9 @@ RUN git clone --depth 1 https://github.com/hpc/mpifileutils.git \
     && make install
 
 FROM mpioperator/openmpi:0.3.0
+
+# Provides nslookup for NNF Containers. Used for MPI Launcher InitContainers.
+RUN apt update && apt install -y dnsutils && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /deps/libcircle/lib/ /usr
 COPY --from=builder /deps/libarchive/lib/ /usr

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mpioperator/openmpi-builder:0.3.0 AS builder
+FROM mpioperator/openmpi-builder:0.4.0 AS builder
 
 RUN apt update
 
@@ -69,7 +69,7 @@ RUN git clone --depth 1 https://github.com/hpc/mpifileutils.git \
         -DCMAKE_INSTALL_PREFIX=/mfu \
     && make install
 
-FROM mpioperator/openmpi:0.3.0
+FROM mpioperator/openmpi:0.4.0
 
 # Provides nslookup for NNF Containers. Used for MPI Launcher InitContainers.
 RUN apt update && apt install -y dnsutils && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This is needed for MPI workflows. The MPI launcher pod uses InitContainers to check that the MPI worker pods are reachable via the network. This is done using `nslookup`.