### PR TITLE
Add debug image for mpirun/dcp symbols

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,23 +1,13 @@
 name: Docker build and push
-
 on:
   push:
     branches:
       - '*'
     tags:
       - 'v*'
-
-env:
-  # TEST_TARGET: Name of the testing target in the Dockerfile
-  TEST_TARGET: testing
-
-  # DO_TEST - true to build and run unit tests, false to skip the tests
-  DO_TEST: false
-
 jobs:
-  build:
+  production:
     runs-on: ubuntu-latest
-
     steps:
     - name: "Build context"
       run: |
@@ -59,7 +49,7 @@ jobs:
           # For PR event or merge event, tag example: 1.0.1.12-5667
           type=raw,value=${{ env.VERSION_TAG }}
           # For PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
-          type=raw,value=${{ env.SHA_TAG }}          
+          type=raw,value=${{ env.SHA_TAG }}
           # For push to semver tag, tag example: 1.0.2
           # This also sets 'latest'.
           type=semver,pattern={{version}}
@@ -68,30 +58,81 @@ jobs:
 
     - name: "Docker login"
       id: docker_login
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: "Build the test Docker image"
-      id: docker_build_test_target
-      if: ${{ env.DO_TEST == 'true' }}
-      uses: docker/build-push-action@v2
-      with:
-        push: false
-        target: ${{ env.TEST_TARGET }}
-        tags: ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
-
-    - name: "Run the Docker image unit tests"
-      id: docker_test
-      if: ${{ env.DO_TEST == 'true' }}
-      run: docker run ${{ env.REPO_NAME }}:${{ env.TEST_TAG }}
 
     - name: "Build the final Docker image"
       id: docker_build
       uses: docker/build-push-action@v3
       with:
         push: true
+        target: production
         tags: ${{ steps.meta.outputs.tags }}
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Build context"
+      run: |
+        echo "ref is ${{ github.ref }}"
+        echo "ref_type is ${{ github.ref_type }}"
 
+    - name: "Checkout repository"
+      id: checkout_repo
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: "Lowercase repository name for docker build"
+      id: lowercase-repository-name
+      run: echo "REPO_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+    - name: "Set tags for main/master"
+      id: set_tags
+      run: |
+        echo "VERSION_TAG=$(./git-version-gen | grep -v UNKNOWN)" >> ${GITHUB_ENV}
+        echo "TEST_TAG=$(git rev-parse HEAD)-test" >> ${GITHUB_ENV}
+        echo "SHA_TAG=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
+        echo "${GITHUB_ENV}:"
+        cat ${GITHUB_ENV}
+      shell: bash
+
+    - name: "Docker metadata"
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/${{ env.REPO_NAME }}-debug
+        tags: |
+          # For merge to master branch, tag example: 'master'
+          type=ref,event=branch
+          # For PR event, tag example: 'pr-3'
+          type=ref,event=pr
+          # For PR event or merge event, tag example: 1.0.1.12-5667
+          type=raw,value=${{ env.VERSION_TAG }}
+          # For PR event or merge, tag example: 566769e04d2436cf5f42ae4f46092c7dff6e668e
+          type=raw,value=${{ env.SHA_TAG }}
+          # For push to semver tag, tag example: 1.0.2
+          # This also sets 'latest'.
+          type=semver,pattern={{version}}
+          # For push to semver tag, tag example: 1.0
+          type=semver,pattern={{major}}.{{minor}}
+
+    - name: "Docker login"
+      id: docker_login
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: "Build the debug Docker image"
+      id: docker_build
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        target: debug
+        tags: ${{ steps.meta.outputs.tags }}

--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,33 @@
 # limitations under the License.
 
 # NOTE: git-version-gen will generate a value for VERSION, unless you override it.
-IMAGE_TAG_BASE ?= ghcr.io/nearnodeflash/mfu
+IMAGE_TAG_BASE ?= ghcr.io/nearnodeflash/nnf-mfu
 
 docker-build: VERSION ?= $(shell cat .version)
 docker-build: .version
-	docker build -t $(IMAGE_TAG_BASE):$(VERSION) .
+	docker build --target production -t $(IMAGE_TAG_BASE):$(VERSION) .
+
+docker-build-debug: VERSION ?= $(shell cat .version)
+docker-build-debug: IMAGE_TAG_BASE := $(IMAGE_TAG_BASE)-debug
+docker-build-debug: .version
+	docker build --target debug -t $(IMAGE_TAG_BASE):$(VERSION) .
 
 docker-push: VERSION ?= $(shell cat .version)
 docker-push: .version
 	docker push $(IMAGE_TAG_BASE):$(VERSION)
 
+docker-push-debug: VERSION ?= $(shell cat .version)
+docker-push-debug: IMAGE_TAG_BASE := $(IMAGE_TAG_BASE)-debug
+docker-push-debug: .version
+	docker push $(IMAGE_TAG_BASE):$(VERSION)
+
 kind-push: VERSION ?= $(shell cat .version)
 kind-push: .version
+	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
+
+kind-push-debug: VERSION ?= $(shell cat .version)
+kind-push-debug: IMAGE_TAG_BASE := $(IMAGE_TAG_BASE)-debug
+kind-push-debug: .version
 	kind load docker-image $(IMAGE_TAG_BASE):$(VERSION)
 
 # Let .version be phony so that a git update to the workarea can be reflected

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,17 @@
 # Near Node Flash - MPI File Utils (MFU)
 
-This repository contains the Dockerfile used to generate an Open MPI image capable of running MPI File Utils commands
+This repository houses the Dockerfile responsible for generating an [Open
+MPI](https://www.open-mpi.org) image with the capability to execute [MPI File
+Utils](https://github.com/hpc/mpifileutils) commands.
 
+The foundation of this image relies on
+[mpi-operator](https://github.com/kubeflow/mpi-operator) with the addition of
+MPI File Utils that have been constructed from source. At the time of this writing, the mpi-operator image installs v4.1.0 of Open MPI.
+
+This image is primarily used for NNF Data Movement and as a base image for running NNF User Containers.
+
+Within this repository, you will find two distinct versions of the image:
+production and debug. The production image is the primary version, encompassing
+the features described above. The debug image incorporates
+versions of OpenMPI and MPI File Utils that have been compiled with debugging
+symbols. This particular image is useful for debugging and has been constructed for the use of analyzing coredumps.


### PR DESCRIPTION
- Split the actions workflow into seperate jobs: production + debug
- Both jobs can run in parallel since the debug build takes some time
- Makefile image name now matches Github

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>