### PR TITLE
Use a pinned version for mpiFileUtils rather than main branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,9 @@ RUN wget https://github.com/llnl/dtcmp/releases/download/v1.1.1/dtcmp-1.1.1.tar.
     && ./configure --prefix=/deps/dtcmp/lib --with-lwgrp=/deps/lwgrp/lib \
     && make install
 
-# Until a new release of mpifileutils is cut, we need to pull the main branch.
-RUN git clone --depth 1 https://github.com/hpc/mpifileutils.git \
+# Until a new release of mpifileutils is cut, we need to use a tagged commit on
+# our fork to include our dcp changes (i.e. --uid, --gid)
+RUN git clone --depth 1 https://github.com/nearnodeflash/mpifileutils.git --branch nnf-stable \
     && mkdir build \
     && cd build \
     && cmake ../mpifileutils \


### PR DESCRIPTION
## Problem
mpiFileUtils latest release is from Feb 2022 and does not include our
fixes to dcp to add UID/GID flags. Using the HEAD commit of mpiFileUtils
is dangerous.

## Solution

- Forked the mpiFileUtils repo into github.com/NearNodeFlash
- Created an `nnf-stable` tag that points to a version that we know is working
- Updated the nnf-mfu Dockerfile to check out the `nnf-stable` tag

Signed-off-by: Blake Devcich <blake.devcich@hpe.com>
