### PR TITLE
Make it easier to build on a Mac

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,20 @@ on: [push]
 
 jobs:
   production:
+    # Testing with nektos/act:
+    #   $ act --rm -j production --container-architecture linux/amd64 --pull=false --bind --action-offline-mode push
+    #
     runs-on: ubuntu-latest
     steps:
     - name: "Build context"
       run: |
+        echo "env.ACT is ${{ env.ACT }}"
         echo "ref is ${{ github.ref }}"
         echo "ref_type is ${{ github.ref_type }}"
+        echo "head.sha is ${{ github.event.pull_request.head.sha }}"
 
     - name: "Checkout repository"
+      if: ${{ !env.ACT }} # skip during local actions testing
       id: checkout_repo
       uses: actions/checkout@v3
       with:
@@ -33,6 +39,7 @@ jobs:
       shell: bash
 
     - name: "Docker metadata"
+      if: ${{ !env.ACT }} # skip during local actions testing
       id: meta
       uses: docker/metadata-action@v4
       with:
@@ -54,6 +61,7 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
 
     - name: "Docker login"
+      if: ${{ !env.ACT }} # skip during local actions testing
       id: docker_login
       uses: docker/login-action@v2
       with:
@@ -62,12 +70,23 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: "Build the final Docker image"
+      if: ${{ !env.ACT }} # skip during local actions testing
       id: docker_build
       uses: docker/build-push-action@v3
       with:
         push: true
         target: production
         tags: ${{ steps.meta.outputs.tags }}
+
+    - name: "Build the final Docker image in nektos/act"
+      # The docker/build-push-action does actions/checkout, and that can't be
+      # turned off. So instead, we run the docker build command directly here
+      # assuming that 'act' was run with the '--bind' arg.
+      if: ${{ env.ACT }} # only during local actions testing
+      id: docker_build_nektos_act
+      run: /usr/bin/docker buildx build --tag ghcr.io/${{ env.REPO_NAME }}:act --target production .
+
+
   debug:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021-2025 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -21,7 +21,7 @@ IMAGE_TAG_BASE ?= ghcr.io/nearnodeflash/nnf-mfu
 docker-build: VERSION ?= $(shell cat .version)
 docker-build: TARGET ?= production
 docker-build: .version
-	docker build --progress plain --target $(TARGET) -t $(IMAGE_TAG_BASE):$(VERSION) .
+	docker build --target $(TARGET) -t $(IMAGE_TAG_BASE):$(VERSION) .
 
 docker-build-debug: VERSION ?= $(shell cat .version)
 docker-build-debug: IMAGE_TAG_BASE := $(IMAGE_TAG_BASE)-debug

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 # Other additional copyright holders may be indicated within.
 #
 # The entirety of this work is licensed under the Apache License,
@@ -21,7 +21,7 @@ IMAGE_TAG_BASE ?= ghcr.io/nearnodeflash/nnf-mfu
 docker-build: VERSION ?= $(shell cat .version)
 docker-build: TARGET ?= production
 docker-build: .version
-	docker build --target $(TARGET) -t $(IMAGE_TAG_BASE):$(VERSION) .
+	docker build --progress plain --target $(TARGET) -t $(IMAGE_TAG_BASE):$(VERSION) .
 
 docker-build-debug: VERSION ?= $(shell cat .version)
 docker-build-debug: IMAGE_TAG_BASE := $(IMAGE_TAG_BASE)-debug

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Utils](https://github.com/hpc/mpifileutils) commands.
 
 The foundation of this image relies on
 [mpi-operator](https://github.com/kubeflow/mpi-operator) with the addition of
-MPI File Utils that have been constructed from source. At the time of this writing, the mpi-operator image installs v4.1.0 of Open MPI.
+MPI File Utils that have been constructed from source.
 
 This image is primarily used for NNF Data Movement and as a base image for running NNF User Containers.
 


### PR DESCRIPTION
The wget in openmpi-builder has trouble with certs when fetching the openmpi source. Disable the cert check and replace it with a checksum check.